### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,30 @@ export default function App() {
 }
 ```
 
+### Get the access token
+
+Sometimes it is useful to obtain the access token directly (e.g. to make API requests to another service).
+
+```jsx
+import { getAccessToken } from '@workos-inc/authkit-nextjs';
+
+export default async function CoolComponent() {
+  const accessToken = await getAccessToken();
+
+  if (!accessToken) {
+    return <div>Not signed in</div>;
+  }
+
+  const serviceData = await fetch('/api/path', {
+    headers: {
+      Authorization: `Bearer ${accessToken}`,
+    },
+  });
+
+  return <div>{serviceData}</div>;
+}
+```
+
 ### Debugging
 
 To enable debug logs, initialize the middleware with the debug flag enabled.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.4.2",
+  "version": "0.5.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@workos-inc/authkit-nextjs",
-      "version": "0.4.2",
+      "version": "0.5.3",
       "license": "MIT",
       "dependencies": {
         "@workos-inc/node": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "commonjs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@workos-inc/authkit-nextjs",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Authentication and session helpers for using WorkOS & AuthKit with Next.js",
   "sideEffects": false,
   "type": "commonjs",

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -22,8 +22,16 @@ export function handleAuth(options: HandleAuthOptions = {}) {
           code,
         });
 
+        const url = request.nextUrl.clone();
+
+        // Cleanup params
+        url.searchParams.delete('code');
+        url.searchParams.delete('state');
+
         // Redirect to the requested path and store the session
-        const response = NextResponse.redirect(returnPathname ?? returnPathnameOption);
+        url.pathname = returnPathname ?? returnPathnameOption;
+
+        const response = NextResponse.redirect(url);
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 

--- a/src/authkit-callback-route.ts
+++ b/src/authkit-callback-route.ts
@@ -22,16 +22,8 @@ export function handleAuth(options: HandleAuthOptions = {}) {
           code,
         });
 
-        const url = request.nextUrl.clone();
-
-        // Cleanup params
-        url.searchParams.delete('code');
-        url.searchParams.delete('state');
-
         // Redirect to the requested path and store the session
-        url.pathname = returnPathname ?? returnPathnameOption;
-
-        const response = NextResponse.redirect(url);
+        const response = NextResponse.redirect(returnPathname ?? returnPathnameOption);
 
         if (!accessToken || !refreshToken) throw new Error('response is missing tokens');
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { handleAuth } from './authkit-callback-route.js';
 import { authkitMiddleware } from './middleware.js';
-import { getUser } from './session.js';
+import { getAccessToken, getUser } from './session.js';
 import { getSignInUrl, getSignUpUrl, signOut } from './auth.js';
 import { Impersonation } from './impersonation.js';
 
@@ -11,6 +11,7 @@ export {
   //
   getSignInUrl,
   getSignUpUrl,
+  getAccessToken,
   getUser,
   signOut,
   //

--- a/src/session.ts
+++ b/src/session.ts
@@ -120,20 +120,17 @@ function getMiddlewareAuthPathRegex(pathGlob: string) {
   }
 }
 
+export async function getAccessToken() {
+  const session = await getSessionFromHeader('getAccessToken');
+  return session?.accessToken;
+}
+
 async function getUser(options?: { ensureSignedIn: false }): Promise<UserInfo | NoUserInfo>;
 
 async function getUser(options: { ensureSignedIn: true }): Promise<UserInfo>;
 
 async function getUser({ ensureSignedIn = false } = {}) {
-  const hasMiddleware = Boolean(headers().get(middlewareHeaderName));
-
-  if (!hasMiddleware) {
-    throw new Error(
-      'You are calling `getUser` on a path that isn’t covered by the AuthKit middleware. Make sure it is running on all paths you are calling `getUser` from by updating your middleware config in `middleware.(js|ts)`.',
-    );
-  }
-
-  const session = await getSessionFromHeader();
+  const session = await getSessionFromHeader('getUser');
   if (!session) {
     if (ensureSignedIn) {
       const url = headers().get('x-url');
@@ -181,7 +178,15 @@ async function getSessionFromCookie() {
   }
 }
 
-async function getSessionFromHeader(): Promise<Session | undefined> {
+async function getSessionFromHeader(caller: string): Promise<Session | undefined> {
+  const hasMiddleware = Boolean(headers().get(middlewareHeaderName));
+
+  if (!hasMiddleware) {
+    throw new Error(
+      `You are calling \`${caller}\` on a path that isn’t covered by the AuthKit middleware. Make sure it is running on all paths you are calling \`${caller}\` from by updating your middleware config in \`middleware.(js|ts)\`.`,
+    );
+  }
+
   const authHeader = headers().get(sessionHeaderName);
   if (!authHeader) return;
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce a new getAccessToken helper to retrieve session access tokens, refactor the middleware coverage check by parameterizing getSessionFromHeader with caller context, export the helper in the public API, and document its usage in the README.

New Features:
- Add getAccessToken() helper for fetching the session access token and export it from the package.

Enhancements:
- Refactor getSessionFromHeader to accept a caller name and centralize the middleware coverage check with improved error messaging.

Documentation:
- Add a README section demonstrating how to use getAccessToken for API requests.